### PR TITLE
Fix balance typo in space-dilation-data

### DIFF
--- a/etc/space_exploration.md
+++ b/etc/space_exploration.md
@@ -169,7 +169,7 @@ Of note: both alternatives exhibit flipped polarity, requiring at least one inve
 Solve paths:
 
     LL x2 + PG  =>  PG -> XO | LO -> XT | LT -> EZ | XZ -> PT | ELPX -> GOTZ | LT -> EZ | ET -> PO
-    LL x2 + XO  =>  LO -> XT | LT -> EZ | XZ -> PT | ELPX -> GOTZ | LT -> EZ | EZ -> PO | PG -> XO
+    LL x2 + XO  =>  LO -> XT | LT -> EZ | XZ -> PT | ELPX -> GOTZ | LT -> EZ | ET -> PO | PG -> XO
     LL x2 + XO  =>  LO -> XT | LT -> EZ | XZ -> PT | LT -> EZ | ELPX -> GOTZ | ET -> PO | PG -> XO
     LL x2 + XT  =>  LT -> EZ | XZ -> PT | ET -> PO | LO -> XT | LT -> EZ | ELPX -> GOTZ | PG -> XO
 


### PR DESCRIPTION
Change `Z` to `T`
`EZ -> PO` should be `ET -> PO`
[#space-dilation-data](https://github.com/matthieu-m/arcosphere/blob/main/etc/space_exploration.md#space-dilation-data)